### PR TITLE
Test file

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "UNLICENSED",
   "scripts": {
     "build": "nest build",
-    "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "format": "prettier --write \".../**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",

--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { Product } from './products.model';
-import { PrismaService } from 'src/prisma/prisma.service';
+import { PrismaService } from '../prisma/prisma.service';
 import {
   EmailAlreadyExistsException,
   NotFoundId,
-} from 'src/users/users.exception';
+} from '../users/users.exception';
 import { CreateProductDto, UpdateProductDto } from './dto/products.dto';
 
 @Injectable()

--- a/src/users/users-controller.spec.ts
+++ b/src/users/users-controller.spec.ts
@@ -105,16 +105,6 @@ describe('UsersCreateTest', () => {
   });
 
   describe('GET/users/:id', () => {
-    it('存在しないIDを指定いる時', async () => {
-      (mockUserService.findById as jest.Mock).mockRejectedValue(
-        new NotFoundId(2),
-      );
-
-      await expect(mockUserService.findById(2)).rejects.toThrow(
-        `指定されたID:2は見つかりませんでした`,
-      );
-    });
-
     it('正常値', async () => {
       const getUser: CreateUserDto = {
         id: 1,
@@ -125,6 +115,16 @@ describe('UsersCreateTest', () => {
 
       (mockUserService.findById as jest.Mock).mockResolvedValue(getUser);
       await expect(usersController.findById(1)).resolves.toEqual(getUser);
+    });
+
+    it('存在しないIDを指定いる時', async () => {
+      (mockUserService.findById as jest.Mock).mockRejectedValue(
+        new NotFoundId(2),
+      );
+
+      await expect(mockUserService.findById(2)).rejects.toThrow(
+        `指定されたID:2は見つかりませんでした`,
+      );
     });
   });
 

--- a/src/users/users-controller.spec.ts
+++ b/src/users/users-controller.spec.ts
@@ -11,6 +11,7 @@ describe('UsersCreateTest', () => {
   const mockUserService = {
     create: jest.fn(),
     findById: jest.fn(),
+    updateUser: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -67,5 +68,38 @@ describe('UsersCreateTest', () => {
       (mockUserService.findById as jest.Mock).mockResolvedValue(getUser);
       await expect(usersController.findById(1)).resolves.toEqual(getUser);
     });
+  });
+
+  describe('PUT/users/:id', () => {
+    it('正常値', async () => {
+      const updateUserDto: CreateUserDto = {
+        id: 1,
+        userName: 'nageihgaiwe',
+        email: 'test@test.com',
+        password: 'password',
+      };
+      const expectedResult: CreateUserDto = {
+        id: 1,
+        userName: 'gaiue',
+        email: 'gna@na.com',
+        password: 'gnaiu',
+      };
+      (mockUserService.updateUser as jest.Mock).mockResolvedValue(
+        expectedResult,
+      );
+      await expect(
+        usersController.updateUser(updateUserDto.id, updateUserDto),
+      ).resolves.toEqual(expectedResult);
+    });
+  });
+
+  it('存在しないIDを指定いる時', async () => {
+    (mockUserService.updateUser as jest.Mock).mockRejectedValue(
+      new NotFoundId(2),
+    );
+
+    await expect(mockUserService.updateUser(2)).rejects.toThrow(
+      `指定されたID:2は見つかりませんでした`,
+    );
   });
 });

--- a/src/users/users-controller.spec.ts
+++ b/src/users/users-controller.spec.ts
@@ -3,6 +3,7 @@ import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { NotFoundId } from './users.exception';
+import { BadRequestException } from '@nestjs/common';
 
 describe('UsersCreateTest', () => {
   let usersController: UsersController;
@@ -44,6 +45,26 @@ describe('UsersCreateTest', () => {
       (mockUserService.create as jest.Mock).mockResolvedValue(createUser);
       await expect(usersController.create(createUser)).resolves.toEqual(
         createUser,
+      );
+    });
+
+    it('ユーザーネームが長すぎる場合', async () => {
+      const createUser: CreateUserDto = {
+        id: 1,
+        userName:
+          'gisaugaiolngighariyua;h;jharoajhiaotliaghrsaejiagheiognaegjaiogiahorgnasejgiagiehanre.aieg',
+        email: 'test@test.com',
+        password: 'password',
+      };
+
+      (mockUserService.create as jest.Mock).mockRejectedValue(() => {
+        throw new BadRequestException(
+          'userName must be shorter than or equal to 50 characters',
+        );
+      });
+
+      await expect(usersController.create(createUser)).rejects.toThrow(
+        'userName must be shorter than or equal to 50 characters',
       );
     });
   });

--- a/src/users/users-controller.spec.ts
+++ b/src/users/users-controller.spec.ts
@@ -67,6 +67,26 @@ describe('UsersCreateTest', () => {
         'userName must be shorter than or equal to 50 characters',
       );
     });
+
+    it('メールアドレスが正しい形式じゃない場合', async () => {
+      const createUser: CreateUserDto = {
+        id: 1,
+        userName: 'test',
+        email: 'test-test.com',
+        password: 'password',
+      };
+
+      (mockUserService.create as jest.Mock).mockRejectedValue(() => {
+        throw new BadRequestException('email must be an email');
+      });
+
+      await expect(usersController.create(createUser)).rejects.toThrow(
+        'email must be an email',
+      );
+    });
+  
+
+
   });
 
   describe('GET/users/:id', () => {

--- a/src/users/users-controller.spec.ts
+++ b/src/users/users-controller.spec.ts
@@ -2,6 +2,7 @@ import { Test } from '@nestjs/testing';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './dto/create-user.dto';
+import { NotFoundId } from './users.exception';
 
 describe('UsersCreateTest', () => {
   let usersController: UsersController;
@@ -9,6 +10,7 @@ describe('UsersCreateTest', () => {
 
   const mockUserService = {
     create: jest.fn(),
+    findById: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -40,6 +42,30 @@ describe('UsersCreateTest', () => {
       await expect(usersController.create(createUser)).resolves.toEqual(
         createUser,
       );
+    });
+  });
+
+  describe('GET/users/:id', () => {
+    it('存在しないIDを指定いる時', async () => {
+      (mockUserService.findById as jest.Mock).mockRejectedValue(
+        new NotFoundId(2),
+      );
+
+      await expect(mockUserService.findById(2)).rejects.toThrow(
+        `指定されたID:2は見つかりませんでした`,
+      );
+    });
+
+    it('正常値', async () => {
+      const getUser: CreateUserDto = {
+        id: 1,
+        userName: 'nageihgaiwe',
+        email: 'test@test.com',
+        password: 'password',
+      };
+
+      (mockUserService.findById as jest.Mock).mockResolvedValue(getUser);
+      await expect(usersController.findById(1)).resolves.toEqual(getUser);
     });
   });
 });

--- a/src/users/users-controller.spec.ts
+++ b/src/users/users-controller.spec.ts
@@ -158,6 +158,65 @@ describe('UsersCreateTest', () => {
         `指定されたID:2は見つかりませんでした`,
       );
     });
+
+    it('ユーザーネームが長すぎる場合', async () => {
+      const createUser: CreateUserDto = {
+        id: 1,
+        userName:
+          'gisaugaiolngighariyua;h;jharoajhiaotliaghrsaejiagheiognaegjaiogiahorgnasejgiagiehanre.aieg',
+        email: 'test@test.com',
+        password: 'password',
+      };
+
+      (mockUserService.updateUser as jest.Mock).mockRejectedValue(() => {
+        throw new BadRequestException(
+          'userName must be shorter than or equal to 50 characters',
+        );
+      });
+
+      await expect(
+        usersController.updateUser(createUser.id, createUser),
+      ).rejects.toThrow(
+        'userName must be shorter than or equal to 50 characters',
+      );
+    });
+
+    it('メールアドレスが正しい形式じゃない場合', async () => {
+      const createUser: CreateUserDto = {
+        id: 1,
+        userName: 'test',
+        email: 'test-test.com',
+        password: 'password',
+      };
+
+      (mockUserService.updateUser as jest.Mock).mockRejectedValue(() => {
+        throw new BadRequestException('email must be an email');
+      });
+
+      await expect(
+        usersController.updateUser(createUser.id, createUser),
+      ).rejects.toThrow('email must be an email');
+    });
+
+    it('パスワードが短い場合', async () => {
+      const createUser: CreateUserDto = {
+        id: 1,
+        userName: 'test',
+        email: 'test@test.com',
+        password: 'ps',
+      };
+      (mockUserService.updateUser as jest.Mock).mockRejectedValue(() => {
+        throw new BadRequestException(
+          'password must be longer than or equal to 6 characters',
+        );
+      });
+
+      await expect(
+        usersController.updateUser(createUser.id, createUser),
+      ).rejects.toThrow(
+        'password must be longer than or equal to 6 characters',
+      );
+    });
   });
 
   describe('DELETE/users/:id', () => {

--- a/src/users/users-controller.spec.ts
+++ b/src/users/users-controller.spec.ts
@@ -32,7 +32,6 @@ describe('UsersCreateTest', () => {
     usersService = module.get<UsersService>(UsersService);
   });
 
-  //バリデーションが抜けている
   describe('POST/users', () => {
     it('正常値', async () => {
       const createUser: CreateUserDto = {

--- a/src/users/users-controller.spec.ts
+++ b/src/users/users-controller.spec.ts
@@ -1,0 +1,27 @@
+import { Test } from '@nestjs/testing';
+import { UsersController } from './users.controller';
+import { UsersService } from './users.service';
+import { CreateUserDto } from './dto/create-user.dto';
+
+describe('UsersCreateTest', () => {
+  let usersController: UsersController;
+  let usersService: UsersService;
+
+  const mockUserService = {};
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module = await Test.createTestingModule({
+      controllers: [UsersController],
+      providers: [
+        {
+          provide: UsersService,
+          useValue: mockUserService,
+        },
+      ],
+    }).compile();
+
+    usersController = module.get<UsersController>(UsersController);
+    usersService = module.get<UsersService>(UsersService);
+  });
+});

--- a/src/users/users-controller.spec.ts
+++ b/src/users/users-controller.spec.ts
@@ -7,7 +7,9 @@ describe('UsersCreateTest', () => {
   let usersController: UsersController;
   let usersService: UsersService;
 
-  const mockUserService = {};
+  const mockUserService = {
+    create: jest.fn(),
+  };
 
   beforeEach(async () => {
     jest.clearAllMocks();
@@ -23,5 +25,21 @@ describe('UsersCreateTest', () => {
 
     usersController = module.get<UsersController>(UsersController);
     usersService = module.get<UsersService>(UsersService);
+  });
+
+  describe('POST/users', () => {
+    it('正常値', async () => {
+      const createUser: CreateUserDto = {
+        id: 1,
+        userName: 'nageihgaiwe',
+        email: 'test@test.com',
+        password: 'password',
+      };
+
+      (mockUserService.create as jest.Mock).mockResolvedValue(createUser);
+      await expect(usersController.create(createUser)).resolves.toEqual(
+        createUser,
+      );
+    });
   });
 });

--- a/src/users/users-controller.spec.ts
+++ b/src/users/users-controller.spec.ts
@@ -31,6 +31,7 @@ describe('UsersCreateTest', () => {
     usersService = module.get<UsersService>(UsersService);
   });
 
+  //バリデーションが抜けている
   describe('POST/users', () => {
     it('正常値', async () => {
       const createUser: CreateUserDto = {
@@ -92,16 +93,16 @@ describe('UsersCreateTest', () => {
         usersController.updateUser(updateUserDto.id, updateUserDto),
       ).resolves.toEqual(expectedResult);
     });
-  });
 
-  it('存在しないIDを指定いる時', async () => {
-    (mockUserService.updateUser as jest.Mock).mockRejectedValue(
-      new NotFoundId(2),
-    );
+    it('存在しないIDを指定いる時', async () => {
+      (mockUserService.updateUser as jest.Mock).mockRejectedValue(
+        new NotFoundId(2),
+      );
 
-    await expect(mockUserService.updateUser(2)).rejects.toThrow(
-      `指定されたID:2は見つかりませんでした`,
-    );
+      await expect(mockUserService.updateUser(2)).rejects.toThrow(
+        `指定されたID:2は見つかりませんでした`,
+      );
+    });
   });
 
   describe('DELETE/users/:id', () => {

--- a/src/users/users-controller.spec.ts
+++ b/src/users/users-controller.spec.ts
@@ -12,6 +12,7 @@ describe('UsersCreateTest', () => {
     create: jest.fn(),
     findById: jest.fn(),
     updateUser: jest.fn(),
+    delete: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -101,5 +102,30 @@ describe('UsersCreateTest', () => {
     await expect(mockUserService.updateUser(2)).rejects.toThrow(
       `指定されたID:2は見つかりませんでした`,
     );
+  });
+
+  describe('DELETE/users/:id', () => {
+    it('正常値', async () => {
+      const deleteUser: CreateUserDto = {
+        id: 1,
+        userName: 'nageihgaiwe',
+        email: 'test@test.com',
+        password: 'password',
+      };
+      (mockUserService.delete as jest.Mock).mockResolvedValue(deleteUser);
+      await expect(usersController.delete(deleteUser.id)).resolves.toEqual(
+        deleteUser,
+      );
+    });
+
+    it('存在しないIDを指定いる時', async () => {
+      (mockUserService.delete as jest.Mock).mockRejectedValue(
+        new NotFoundId(2),
+      );
+
+      await expect(mockUserService.delete(2)).rejects.toThrow(
+        `指定されたID:2は見つかりませんでした`,
+      );
+    });
   });
 });

--- a/src/users/users-controller.spec.ts
+++ b/src/users/users-controller.spec.ts
@@ -84,9 +84,24 @@ describe('UsersCreateTest', () => {
         'email must be an email',
       );
     });
-  
 
+    it('パスワードが短い場合', async () => {
+      const createUser: CreateUserDto = {
+        id: 1,
+        userName: 'test',
+        email: 'test@test.com',
+        password: 'ps',
+      };
+      (mockUserService.create as jest.Mock).mockRejectedValue(() => {
+        throw new BadRequestException(
+          'password must be longer than or equal to 6 characters',
+        );
+      });
 
+      await expect(usersController.create(createUser)).rejects.toThrow(
+        'password must be longer than or equal to 6 characters',
+      );
+    });
   });
 
   describe('GET/users/:id', () => {

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
-import { PrismaModule } from '.../prisma/prisma.module';
+import { PrismaModule } from '../prisma/prisma.module';
 
 @Module({
   imports: [PrismaModule],

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
-import { PrismaModule } from 'src/prisma/prisma.module';
+import { PrismaModule } from '.../prisma/prisma.module';
 
 @Module({
   imports: [PrismaModule],

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -3,14 +3,14 @@ import { UsersService } from './users.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { EmailAlreadyExistsException, NotFoundId } from './users.exception';
-import { ROUTES } from '@nestjs/core/router/router-module';
-import { PassThrough } from 'stream';
+import { UpdateUserDto } from './dto/update-user.dto';
 
 const mockPrismaService = {
   user: {
     create: jest.fn(),
     findUnique: jest.fn(),
     findById: jest.fn(),
+    update: jest.fn(),
   },
 };
 
@@ -88,6 +88,38 @@ describe('UsersServieTest', () => {
       (prismaService.user.findUnique as jest.Mock).mockResolvedValue({});
       const expected = {};
       await expect(usersService.findById(1)).resolves.toEqual(expected);
+    });
+  });
+
+  describe('update', () => {
+    it('idが見つからなかった時', async () => {
+      (prismaService.user.findUnique as jest.Mock).mockRejectedValue(
+        new NotFoundId(99868),
+      );
+
+      await expect(usersService.findById(99868)).rejects.toThrow(
+        `指定されたID:99868は見つかりませんでした`,
+      );
+    });
+
+    it('正常系', async () => {
+      const updateUserDto: UpdateUserDto = {
+        id: 297452,
+        userName: 'ganioseogah',
+        email: 'ganjkeghwiyt@ngan.gaiue',
+        password: 'hgkalhaiehga',
+      };
+
+      (prismaService.user.findUnique as jest.Mock).mockResolvedValue(297452);
+      (prismaService.user.update as jest.Mock).mockResolvedValue(updateUserDto);
+      await expect(
+        usersService.updateUser(297452, updateUserDto),
+      ).resolves.toEqual({
+        id: 297452,
+        userName: 'ganioseogah',
+        email: 'ganjkeghwiyt@ngan.gaiue',
+        password: 'hgkalhaiehga',
+      });
     });
   });
 });

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -9,8 +9,8 @@ const mockPrismaService = {
   user: {
     create: jest.fn(),
     findUnique: jest.fn(),
-    findById: jest.fn(),
     update: jest.fn(),
+    delete: jest.fn(),
   },
 };
 
@@ -119,6 +119,35 @@ describe('UsersServieTest', () => {
         userName: 'ganioseogah',
         email: 'ganjkeghwiyt@ngan.gaiue',
         password: 'hgkalhaiehga',
+      });
+    });
+  });
+
+  describe('delete', () => {
+    it('idが見つからなかった時', async () => {
+      (prismaService.user.findUnique as jest.Mock).mockRejectedValue(
+        new NotFoundId(99868),
+      );
+
+      await expect(usersService.findById(99868)).rejects.toThrow(
+        `指定されたID:99868は見つかりませんでした`,
+      );
+    });
+
+    it('正常値', async () => {
+      const deleteUserDto: CreateUserDto = {
+        id: 93251,
+        userName: 'anguaew',
+        email: 'lajga@gnae.com',
+        password: 'glairhaowe',
+      };
+      (prismaService.user.findUnique as jest.Mock).mockResolvedValue(93251);
+      (prismaService.user.delete as jest.Mock).mockResolvedValue(deleteUserDto);
+      await expect(usersService.delete(93251)).resolves.toEqual({
+        id: 93251,
+        userName: 'anguaew',
+        email: 'lajga@gnae.com',
+        password: 'glairhaowe',
       });
     });
   });

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -35,22 +35,6 @@ describe('UsersServieTest', () => {
   });
 
   describe('create', () => {
-    it('emailが重複している時', async () => {
-      const createUserDto: CreateUserDto = {
-        id: 1,
-        userName: 'test',
-        email: 'test@test.com',
-        password: 'password',
-      };
-
-      (prismaService.user.findUnique as jest.Mock).mockResolvedValue(
-        createUserDto,
-      );
-
-      await expect(usersService.create(createUserDto)).rejects.toThrow(
-        'メールアドレス:test@test.comは既に登録されています',
-      );
-    });
     it('正常系', async () => {
       const createUserDto: CreateUserDto = {
         id: 1,
@@ -66,6 +50,23 @@ describe('UsersServieTest', () => {
         email: 'test1@test.com',
         password: 'password',
       });
+    });
+
+    it('emailが重複している時', async () => {
+      const createUserDto: CreateUserDto = {
+        id: 1,
+        userName: 'test',
+        email: 'test@test.com',
+        password: 'password',
+      };
+
+      (prismaService.user.findUnique as jest.Mock).mockResolvedValue(
+        createUserDto,
+      );
+
+      await expect(usersService.create(createUserDto)).rejects.toThrow(
+        'メールアドレス:test@test.comは既に登録されています',
+      );
     });
   });
 

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -4,6 +4,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { EmailAlreadyExistsException, NotFoundId } from './users.exception';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { NotFoundException } from '@nestjs/common';
 
 const mockPrismaService = {
   user: {
@@ -41,14 +42,15 @@ describe('UsersServieTest', () => {
         email: 'test@test.com',
         password: 'password',
       };
-      (prismaService.user.findUnique as jest.Mock).mockRejectedValue(
-        new EmailAlreadyExistsException('test@test.com'),
+
+      (prismaService.user.findUnique as jest.Mock).mockResolvedValue(
+        createUserDto,
       );
+
       await expect(usersService.create(createUserDto)).rejects.toThrow(
         'メールアドレス:test@test.comは既に登録されています',
       );
     });
-
     it('正常系', async () => {
       const createUserDto: CreateUserDto = {
         id: 1,
@@ -69,9 +71,7 @@ describe('UsersServieTest', () => {
 
   describe('findById', () => {
     it('idが見つからなかった時', async () => {
-      (prismaService.user.findUnique as jest.Mock).mockRejectedValue(
-        new NotFoundId(2),
-      );
+      (prismaService.user.findUnique as jest.Mock).mockResolvedValue(null);
 
       await expect(usersService.findById(2)).rejects.toThrow(
         `指定されたID:2は見つかりませんでした`,
@@ -93,13 +93,16 @@ describe('UsersServieTest', () => {
 
   describe('update', () => {
     it('idが見つからなかった時', async () => {
-      (prismaService.user.findUnique as jest.Mock).mockRejectedValue(
-        new NotFoundId(99868),
-      );
+      (prismaService.user.findUnique as jest.Mock).mockResolvedValue(null);
 
-      await expect(usersService.findById(99868)).rejects.toThrow(
-        `指定されたID:99868は見つかりませんでした`,
-      );
+      await expect(
+        usersService.updateUser(99868, {
+          id: 1,
+          userName: 'test',
+          email: 'test1@test.com',
+          password: 'password',
+        }),
+      ).rejects.toThrow('指定されたID:99868は見つかりませんでした');
     });
 
     it('正常系', async () => {
@@ -110,27 +113,27 @@ describe('UsersServieTest', () => {
         password: 'hgkalhaiehga',
       };
 
-      (prismaService.user.findUnique as jest.Mock).mockResolvedValue(297452);
-      (prismaService.user.update as jest.Mock).mockResolvedValue(updateUserDto);
-      await expect(
-        usersService.updateUser(297452, updateUserDto),
-      ).resolves.toEqual({
+      (prismaService.user.findUnique as jest.Mock).mockResolvedValue({
         id: 297452,
         userName: 'ganioseogah',
         email: 'ganjkeghwiyt@ngan.gaiue',
         password: 'hgkalhaiehga',
       });
+
+      (prismaService.user.update as jest.Mock).mockResolvedValue(updateUserDto);
+
+      await expect(
+        usersService.updateUser(297452, updateUserDto),
+      ).resolves.toEqual(updateUserDto);
     });
   });
 
   describe('delete', () => {
     it('idが見つからなかった時', async () => {
-      (prismaService.user.findUnique as jest.Mock).mockRejectedValue(
-        new NotFoundId(99868),
-      );
+      (prismaService.user.findUnique as jest.Mock).mockResolvedValue(null);
 
-      await expect(usersService.findById(99868)).rejects.toThrow(
-        `指定されたID:99868は見つかりませんでした`,
+      await expect(usersService.delete(99868)).rejects.toThrow(
+        NotFoundException,
       );
     });
 
@@ -141,14 +144,12 @@ describe('UsersServieTest', () => {
         email: 'lajga@gnae.com',
         password: 'glairhaowe',
       };
-      (prismaService.user.findUnique as jest.Mock).mockResolvedValue(93251);
+      (prismaService.user.findUnique as jest.Mock).mockResolvedValue(
+        deleteUserDto,
+      );
       (prismaService.user.delete as jest.Mock).mockResolvedValue(deleteUserDto);
-      await expect(usersService.delete(93251)).resolves.toEqual({
-        id: 93251,
-        userName: 'anguaew',
-        email: 'lajga@gnae.com',
-        password: 'glairhaowe',
-      });
+
+      await expect(usersService.delete(93251)).resolves.toEqual(deleteUserDto);
     });
   });
 });

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -130,14 +130,6 @@ describe('UsersServieTest', () => {
   });
 
   describe('delete', () => {
-    it('idが見つからなかった時', async () => {
-      (prismaService.user.findUnique as jest.Mock).mockResolvedValue(null);
-
-      await expect(usersService.delete(99868)).rejects.toThrow(
-        NotFoundException,
-      );
-    });
-
     it('正常値', async () => {
       const deleteUserDto: CreateUserDto = {
         id: 93251,
@@ -153,4 +145,12 @@ describe('UsersServieTest', () => {
       await expect(usersService.delete(93251)).resolves.toEqual(deleteUserDto);
     });
   });
+
+  it('idが見つからなかった時', async () => {
+    (prismaService.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+    await expect(usersService.delete(99868)).rejects.toThrow(NotFoundException);
+  });
+
+    
 });

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -1,0 +1,28 @@
+import { Test } from '@nestjs/testing';
+import { UsersService } from './users.service';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+const mockPrismaService = {
+  user: {
+    create: jest.fn(),
+  },
+};
+
+describe('UsersServieTest', () => {
+  let usersService: UsersService;
+  let prismaService: PrismaService;
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        UsersService,
+        {
+          provide: PrismaService,
+          useValue: mockPrismaService,
+        },
+      ],
+    }).compile();
+
+    usersService = module.get<UsersService>(UsersService);
+    prismaService = module.get<PrismaService>(PrismaService);
+  });
+});

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -93,19 +93,6 @@ describe('UsersServieTest', () => {
   });
 
   describe('update', () => {
-    it('idが見つからなかった時', async () => {
-      (prismaService.user.findUnique as jest.Mock).mockResolvedValue(null);
-
-      await expect(
-        usersService.updateUser(99868, {
-          id: 1,
-          userName: 'test',
-          email: 'test1@test.com',
-          password: 'password',
-        }),
-      ).rejects.toThrow('指定されたID:99868は見つかりませんでした');
-    });
-
     it('正常系', async () => {
       const updateUserDto: UpdateUserDto = {
         id: 297452,
@@ -126,6 +113,19 @@ describe('UsersServieTest', () => {
       await expect(
         usersService.updateUser(297452, updateUserDto),
       ).resolves.toEqual(updateUserDto);
+    });
+
+    it('idが見つからなかった時', async () => {
+      (prismaService.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+      await expect(
+        usersService.updateUser(99868, {
+          id: 1,
+          userName: 'test',
+          email: 'test1@test.com',
+          password: 'password',
+        }),
+      ).rejects.toThrow('指定されたID:99868は見つかりませんでした');
     });
   });
 

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -71,14 +71,6 @@ describe('UsersServieTest', () => {
   });
 
   describe('findById', () => {
-    it('idが見つからなかった時', async () => {
-      (prismaService.user.findUnique as jest.Mock).mockResolvedValue(null);
-
-      await expect(usersService.findById(2)).rejects.toThrow(
-        `指定されたID:2は見つかりませんでした`,
-      );
-    });
-
     it('正常系', async () => {
       const createUserDto: CreateUserDto = {
         id: 1,
@@ -89,6 +81,14 @@ describe('UsersServieTest', () => {
       (prismaService.user.findUnique as jest.Mock).mockResolvedValue({});
       const expected = {};
       await expect(usersService.findById(1)).resolves.toEqual(expected);
+    });
+
+    it('idが見つからなかった時', async () => {
+      (prismaService.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+      await expect(usersService.findById(2)).rejects.toThrow(
+        `指定されたID:2は見つかりませんでした`,
+      );
     });
   });
 

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -3,7 +3,7 @@ import { User } from './users.model';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { EmailAlreadyExistsException, NotFoundId } from './users.exception';
-import { PrismaService } from 'src/prisma/prisma.service';
+import { PrismaService } from '../prisma/prisma.service';
 
 @Injectable()
 export class UsersService {
@@ -34,7 +34,7 @@ export class UsersService {
       where: { email: createUserDto.email },
     });
     if (emailExists) {
-      throw new EmailAlreadyExistsException('createuserDto.email');
+      throw new EmailAlreadyExistsException(createUserDto.email);
     }
     const { userName, email, password } = createUserDto;
     return await this.prismaService.user.create({

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { App } from 'supertest/types';
-import { AppModule } from './../src/app.module';
+import { AppModule } from './../.../app.module';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication<App>;


### PR DESCRIPTION
テスト実行結果
ターミナルでnpx run testを実行させた結果
<img width="454" height="225" alt="スクリーンショット 2025-07-17 午後4 14 24" src="https://github.com/user-attachments/assets/e241febe-cf59-49a4-848c-6247bb0df3d7" />

カバレッジレポート
ターミナルでnpx jest --coverageを実行させた結果
今回要件となっていたのはUsers ControllerとUsers Serviceであり、メソッドも全てが要件になっていなかったためUsers ControllerとUsers ServiceのfindAllがそれぞれ実行結果に含まれていません
<img width="658" height="525" alt="スクリーンショット 2025-07-17 午後4 19 12" src="https://github.com/user-attachments/assets/29d210e6-cb9e-4aec-bb4b-9acc8a717488" />
